### PR TITLE
fix(build): remove unsupported libtoolize -i option

### DIFF
--- a/cyrus-sasl/autogen.sh
+++ b/cyrus-sasl/autogen.sh
@@ -32,7 +32,7 @@ fi
 
 cd saslauthd || exit $?
 rm -f aclocal.m4
-libtoolize -fic || exit $?
+libtoolize -f -c || exit $?
 aclocal --force -I ../cmulocal -I ../config || exit $?
 echo "cyrus after aclocal2"
 if type stat >/dev/null 2>&1; then


### PR DESCRIPTION
The libtoolize -i option is not supported on older platforms