### PR TITLE
fix: When calculating the group string length include length of PBIS.…

### DIFF
--- a/MakeKitBuild
+++ b/MakeKitBuild
@@ -136,7 +136,7 @@ configure()
     LW_PRODUCT_VERSION=9.1
 #   Update LW_PRODUCT_QFE with each release, resetting to zero when the
 #   LW_PRODUCT_VERSION changes.
-    LW_PRODUCT_QFE=1
+    LW_PRODUCT_QFE=2
     LW_VERSION="${LW_PRODUCT_VERSION}.${LW_PRODUCT_QFE}.${LW_BUILD_ID:-0}"
 
     mk_declare -i \


### PR DESCRIPTION
… Its used as a marker for AD group password field (#302)